### PR TITLE
update CTL release tag

### DIFF
--- a/Formula/wish-ctl.rb
+++ b/Formula/wish-ctl.rb
@@ -1,7 +1,7 @@
 class WishCtl < Formula
   desc "Concurrent multi-cluster Kubernetes utility and management tool"
   homepage "https://github.com/wish/ctl"
-  url "https://github.com/wish/ctl", :using => :git, :tag => "v13.0.3"
+  url "https://github.com/wish/ctl", :using => :git, :tag => "20200721"
 
   depends_on "go" => :build
   depends_on "wget"


### PR DESCRIPTION
Update to latest release (go upgraded from 1.12 to 1.13)- 20200721 - https://github.com/wish/ctl/releases/tag/20200721