### PR TITLE
Update Go version for CTL formula to 1.16

### DIFF
--- a/Formula/wish-ctl.rb
+++ b/Formula/wish-ctl.rb
@@ -1,9 +1,9 @@
 class WishCtl < Formula
   desc "Concurrent multi-cluster Kubernetes utility and management tool"
   homepage "https://github.com/wish/ctl"
-  url "https://github.com/wish/ctl", :using => :git, :tag => "v14.2.0"
+  url "https://github.com/wish/ctl", :using => :git, :tag => "v14.3.0"
 
-  depends_on "go@1.15" => :build
+  depends_on "go@1.16" => :build
   depends_on "wget"
   depends_on "git"
   depends_on "kubectl"

--- a/Formula/wish-ctl.rb
+++ b/Formula/wish-ctl.rb
@@ -11,8 +11,8 @@ class WishCtl < Formula
   def install
     ENV["CGO_ENABLED"] = "0"
     ENV["GOOS"] = "darwin"
-    system "sh", "-c", "GOCACHE= GOPATH= go get -v -u github.com/gobuffalo/packr/v2/packr2; $HOME/go/bin/packr2"
-    system "go", "build", "-o", "bin/darwin/ctl", "github.com/wish/ctl"
+    system "sh", "-c", "GOCACHE= GOPATH= go get -v github.com/gobuffalo/packr/v2/packr2; $HOME/go/bin/packr2"
+    system "go", "build", "-mod", "vendor", "-o", "bin/darwin/ctl", "github.com/wish/ctl"
     bin.install "bin/darwin/ctl" => "ctl"
   end
 


### PR DESCRIPTION
Latest wish-ctl [tag - v14.3.0](https://github.com/wish/ctl/releases/tag/v14.3.0)

- Update the build command to explicitly use the vendor library in the `wish-ctl` repo [default behavior since Go.1.14]
- Updated the command to update packr package to not use the `-u` flag as it was updating the package and causing conflicts with the vendor directory:

> The -u flag instructs get to use the network to update the named packages
> and their dependencies. By default, get uses the network to check out
> missing packages but does not use it to look for updates to existing packages.

Conflicts when the `packr` library (and it's dependencies) were updated 
```
==> sh -c GOCACHE= GOPATH= go get -v -u github.com/gobuffalo/packr/v2/packr2; $HOME/go/bin/packr2
==> go build -mod vendor -o bin/darwin/ctl github.com/wish/ctl
Last 15 lines from /Users/phariharan/Library/Logs/Homebrew/wish-ctl/02.go:
        github.com/spf13/viper@v1.7.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        golang.org/x/crypto@v0.0.0-20210322153248-0c34fe9e7dc2: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        golang.org/x/sys@v0.0.0-20210403161142-5e06dd20ab57: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        golang.org/x/term@v0.0.0-20210406210042-72f3dc4e9b72: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        golang.org/x/tools@v0.1.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
        github.com/spf13/cobra@v1.0.0: is marked as explicit in vendor/modules.txt, but not explicitly required in go.mod
        github.com/spf13/viper@v1.6.2: is marked as explicit in vendor/modules.txt, but not explicitly required in go.mod
        golang.org/x/crypto@v0.0.0-20200709230013-948cd5f35899: is marked as explicit in vendor/modules.txt, but not explicitly required in go.mod
        golang.org/x/net@v0.0.0-20200226121028-0de0cce0169b: is marked as explicit in vendor/modules.txt, but not explicitly required in go.mod
        go
```